### PR TITLE
Add CI checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,37 @@
+name: PR Checks
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go_version:
+          - "1.23"
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go_version }}
+      - name: run tests
+        run: go test -coverprofile coverage.out ./...
+      - name: check coverage
+        run: |
+          go run gitlab.com/matthewhughes/go-cov/cmd/go-cov add-skips coverage.out > go-cov.out
+          go run gitlab.com/matthewhughes/go-cov/cmd/go-cov report --fail-under 100 go-cov.out
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,12 @@ repos:
 -   repo: https://github.com/matthewhughes934/pre-commit-format-markdown
     rev: v0.5.0
     hooks:
-    -   id: format-markdown-script
+    -   id: format-markdown-docker
 -   repo: https://github.com/golangci/golangci-lint
     rev: v1.60.2
     hooks:
     -   id: golangci-lint-full
+        language_version: "1.23.0"
 -   repo: https://gitlab.com/matthewhughes/common-changelog
     rev: v0.2.0
     hooks:


### PR DESCRIPTION
- Add CI checks

- Update `pre-commit` config

    User Docker version of markdown formatter, since this works with Github
    actions.

    Override the version of Go for the `golangci-lint` action. We need 1.23
    here since that's the only version this library supports