### PR TITLE
Fix race condition in `IterCtx*` functions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       - name: run tests
-        run: go test -coverprofile coverage.out ./...
+        run: go test -race -coverprofile coverage.out ./...
       - name: check coverage
         run: |
           go run gitlab.com/matthewhughes/go-cov/cmd/go-cov add-skips coverage.out > go-cov.out


### PR DESCRIPTION
The race was the result of the `next` and `stop` functions from `tier.Pull`, `iter.Pull2` being called in separate go-routines. This was discovered while testing with `-race` so be sure to use that in the GitHub actions.

Sample race output:

    $ go test -run 'ExampleIterCtx$' -race ./...
    <--- SNIP --->
    WARNING: DATA RACE
    Read at 0x00c00012cd2f by goroutine 16:
      iter.Pull[go.shape.string].func2()
          /usr/lib/go/src/iter/iter.go:289 +0x6e
      github.com/matthewhughes934/go-itertools/itertools_test.ExampleIterCtx.IterCtx[go.shape.string].func2.1()
          /home/mjh/src/personal/go-itertools/itertools/itertools.go:560 +0x54

    Previous write at 0x00c00012cd2f by main goroutine:
      iter.Pull[go.shape.string].func3()
          /usr/lib/go/src/iter/iter.go:315 +0x6b
      runtime.deferreturn()
          /usr/lib/go/src/runtime/panic.go:605 +0x5d
      github.com/matthewhughes934/go-itertools/itertools_test.ExampleIterCtx()
          /home/mjh/src/personal/go-itertools/itertools/itertools_examples_test.go:536 +0x23b
      testing.runExample()
          /usr/lib/go/src/testing/run_example.go:63 +0x4e1
      testing.runExamples()
          /usr/lib/go/src/testing/example.go:40 +0x214
      testing.(*M).Run()
          /usr/lib/go/src/testing/testing.go:2036 +0x107c
      main.main()
          _testmain.go:209 +0x164

    Goroutine 16 (running) created at:
      github.com/matthewhughes934/go-itertools/itertools_test.ExampleIterCtx.IterCtx[go.shape.string].func2()
          /home/mjh/src/personal/go-itertools/itertools/itertools.go:559 +0x2f6
      github.com/matthewhughes934/go-itertools/itertools_test.ExampleIterCtx()
          /home/mjh/src/personal/go-itertools/itertools/itertools_examples_test.go:536 +0x23b
      testing.runExample()
          /usr/lib/go/src/testing/run_example.go:63 +0x4e1
      testing.runExamples()
          /usr/lib/go/src/testing/example.go:40 +0x214
      testing.(*M).Run()
          /usr/lib/go/src/testing/testing.go:2036 +0x107c
      main.main()
          _testmain.go:209 +0x164