### PR TITLE
Update `pre-commit`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,5 @@ linters:
     - testpackage
     - varnamelen
     - wsl
-    # a bit annoying in tests https://github.com/Abirdcfly/dupword/issues/20
-    - dupword
     # https://github.com/daixiang0/gci/issues/209
     - gci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: format-markdown-docker
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.60.2
+    rev: v1.61.0
     hooks:
     -   id: golangci-lint-full
         language_version: "1.23.0"


### PR DESCRIPTION
via `pre-commit autoupdate` this dragged in an update for `golangci-lint` which dragged in my fix for the `dupword` issue, so re-enabling that linter.