### PR TITLE
Fix warning from `setup-python`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -34,4 +34,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Fix warning:

    The `python-version` input is not set. The version of Python currently in `PATH` will be used.

By adding a `python-version`, specifically using the latest stable Python 3 release[1]

[1] https://github.com/actions/setup-python/blob/70dcb22d269dc9546a5d97f4b11548f130526421/docs/advanced-usage.md#specifying-a-python-version