### PR TITLE
Add some more funcs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,15 +15,20 @@ linters-settings:
     require-specific: true
   errorlint:
     errorf: false
-  goimports:
-    local-prefixes: github.com/matthewhughes934/go-itertools
+  gci:
+    sections:
+      - standard
+      - default
+      - localmodule
 linters:
   enable-all: true
 
   disable:
     # deprecated linters
-    - gomnd
-    - execinquery
+    - exportloopref
+
+    # conflicting/cover same issues
+    - forcetypeassert # covered by errcheck
 
     # personal preference
     - gocritic
@@ -37,5 +42,6 @@ linters:
     - testpackage
     - varnamelen
     - wsl
-    # https://github.com/daixiang0/gci/issues/209
-    - gci
+    # premature optimisation that creates inconsistent code (sometimes Sprintf, sometimes string concatenation)
+    # consider enabling _if_ you've profiled performance _and_ Sprintf calls are slowing you down
+    - perfsprint

--- a/itertools/itertools.go
+++ b/itertools/itertools.go
@@ -794,3 +794,25 @@ func Flatten[K comparable](seq iter.Seq2[K, K]) iter.Seq[K] {
 func FlattenMap[K comparable](m map[K]K) iter.Seq[K] {
 	return Flatten(maps.All(m))
 }
+
+// Pairwise returns successive overlapping pairs taken from the input sequence.
+// It will be empty if the input iterable has fewer than two values.
+func Pairwise[V comparable](seq iter.Seq[V]) iter.Seq2[V, V] {
+	return func(yield func(V, V) bool) {
+		next, stop := iter.Pull(seq)
+		defer stop()
+
+		prev, ok := next()
+		if !ok {
+			return
+		}
+
+		for {
+			next, ok := next()
+			if !ok || !yield(prev, next) {
+				return
+			}
+			prev = next
+		}
+	}
+}

--- a/itertools/itertools.go
+++ b/itertools/itertools.go
@@ -692,7 +692,8 @@ func IterCtx2[K comparable, V any](ctx context.Context, seq iter.Seq2[K, V]) ite
 // Slice returns a [iter.Seq] that slices up the provided sequence: returning
 // elements step distance apart from start until end (excluding end).
 //
-// Slice will panic if step is not a positive integer.
+// If 'end' is negative then the returned sequence will run until 'seq' is
+// exhausted. Slice will panic if step is not a positive integer.
 func Slice[V any](seq iter.Seq[V], start int, end int, step int) iter.Seq[V] {
 	if step <= 0 {
 		panic("step for Slice must be a positive integer")
@@ -707,7 +708,7 @@ func Slice[V any](seq iter.Seq[V], start int, end int, step int) iter.Seq[V] {
 			}
 		}
 
-		for i := start; i < end; i++ {
+		for i := start; end < 0 || i < end; i++ {
 			v, ok := next()
 			if !ok {
 				return
@@ -727,6 +728,13 @@ func Slice[V any](seq iter.Seq[V], start int, end int, step int) iter.Seq[V] {
 //	Slice(seq, 0, end, step)
 func SliceUntil[V any](seq iter.Seq[V], end int, step int) iter.Seq[V] {
 	return Slice(seq, 0, end, step)
+}
+
+// SliceFrom is equivalent to
+//
+//	Slice(seq, start, -1, end)
+func SliceFrom[V any](seq iter.Seq[V], start int, step int) iter.Seq[V] {
+	return Slice(seq, start, -1, step)
 }
 
 // Slice2 is like [Slice] but for [iter.Seq2].
@@ -751,7 +759,7 @@ func Slice2[K comparable, V any](
 			}
 		}
 
-		for i := start; i < end; i++ {
+		for i := start; end < 0 || i < end; i++ {
 			k, v, ok := next()
 			if !ok {
 				return
@@ -769,6 +777,11 @@ func Slice2[K comparable, V any](
 // SliceUntil2 is like [SliceUntil] but for [iter.Seq2].
 func SliceUntil2[K comparable, V any](seq iter.Seq2[K, V], end int, step int) iter.Seq2[K, V] {
 	return Slice2(seq, 0, end, step)
+}
+
+// SliceFrom2 is like [SliceFrom] but for [iter.Seq2].
+func SliceFrom2[K comparable, V any](seq iter.Seq2[K, V], start int, step int) iter.Seq2[K, V] {
+	return Slice2(seq, start, -1, step)
 }
 
 // Flatten returns a sequence that iterates across all keys and then all

--- a/itertools/itertools_examples_test.go
+++ b/itertools/itertools_examples_test.go
@@ -673,6 +673,20 @@ func ExampleSliceUntil() {
 	// E
 }
 
+func ExampleSliceFrom() {
+	seq := slices.Values([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	for s := range itertools.SliceFrom(seq, 0, 3) {
+		fmt.Println(s)
+	}
+
+	// output:
+	// 1
+	// 4
+	// 7
+	// 10
+}
+
 func ExampleSlice2() {
 	seq := itertools.ZipPair(
 		slices.Values([]int{1, 2, 3, 4, 5}),
@@ -701,6 +715,24 @@ func ExampleSliceUntil2() {
 	// output:
 	// 1 11
 	// 3 13
+}
+
+func ExampleSliceFrom2() {
+	seq := itertools.ZipPair(
+		itertools.Range(0, 10, 1),
+		itertools.Range(1, 11, 1),
+	)
+
+	for x1, x2 := range itertools.SliceFrom2(seq, 0, 2) {
+		fmt.Println(x1, x2)
+	}
+
+	// output:
+	// 0 1
+	// 2 3
+	// 4 5
+	// 6 7
+	// 8 9
 }
 
 func ExampleRange() {

--- a/itertools/itertools_examples_test.go
+++ b/itertools/itertools_examples_test.go
@@ -786,3 +786,19 @@ func ExampleFlattenMap() {
 	// goodbye
 	// all
 }
+
+func ExamplePairwise() {
+	seq := slices.Values([]string{"A", "B", "C", "D", "E", "F", "G"})
+
+	for n, m := range itertools.Pairwise(seq) {
+		fmt.Println(n, m)
+	}
+
+	// output:
+	// A B
+	// B C
+	// C D
+	// D E
+	// E F
+	// F G
+}

--- a/itertools/itertools_test.go
+++ b/itertools/itertools_test.go
@@ -800,3 +800,12 @@ func TestIterCtx2_inputExhausted(t *testing.T) {
 
 	require.Equal(t, expected, got)
 }
+
+func TestPairwise_emptyIfFewerThanTwo(t *testing.T) {
+	for _, vals := range [][]int{{}, {1}} {
+		t.Run(fmt.Sprintf("%d", len(vals)), func(t *testing.T) {
+			iter := itertools.Pairwise(slices.Values(vals))
+			require.Empty(t, maps.Collect(iter))
+		})
+	}
+}


### PR DESCRIPTION
- Allow slicing to exhaust entire input

    Via setting `end` to `-1`, and add convenience functions for invoking
    this.

- Sync `golangci-lint` config

    Syncing with[1]

    Link: https://gitlab.com/matthewhughes/golangci-lint-defaults/-/blob/1959b920677aaba3fe489b3d8df3276dd900d24a/.golangci.yaml [1]

- Add `pairwise` function

    Inspired by[1]

    Link: https://docs.python.org/3/library/itertools.html#itertools.pairwise [1]
