### PR TITLE
Misc updates

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.23"
+          - oldstable
+          - stable
         os:
           - windows-latest
           - ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,13 @@
+version: "2"
 run:
   tests: true
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-  revive:
-    rules:
-      - name: exported
-        disabled: true
-      - name: context-as-argument
-        disabled: false
-  nolintlint:
-    require-specific: true
-  errorlint:
-    errorf: false
-  gci:
-    sections:
-      - standard
-      - default
-      - localmodule
 linters:
-  enable-all: true
-
+  default: all
   disable:
-    # deprecated linters
-    - exportloopref
-
     # conflicting/cover same issues
     - forcetypeassert # covered by errcheck
+    - lll # covered outside of golangci-lint (by golines)
 
-    # personal preference
     - gocritic
     - depguard
     - funlen
@@ -45,3 +22,56 @@ linters:
     # premature optimisation that creates inconsistent code (sometimes Sprintf, sometimes string concatenation)
     # consider enabling _if_ you've profiled performance _and_ Sprintf calls are slowing you down
     - perfsprint
+    # the default forbidden list is a bit annoying, especially for debugging: let me Println if I want do
+    - forbidigo
+    # magic numbers are too subjective for a simple linter
+    - mnd
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    errorlint:
+      errorf: false
+    nolintlint:
+      require-specific: true
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: context-as-argument
+          disabled: false
+    staticcheck:
+      checks:
+        # ST1006: receiver name should be a reflection of its identity; don't use generic names such as "this" or "self"
+        # I disagree with this: https://gitlab.com/matthewhughes/mh-lint/-/tree/main/analyzers/methodreceiverself
+        - -ST1006
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,19 +4,13 @@ repos:
     hooks:
     -   id: format-markdown-docker
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.62.2
+    rev: v2.1.5
     hooks:
     -   id: golangci-lint-full
-        language_version: "1.23.0"
 -   repo: https://gitlab.com/matthewhughes/common-changelog
     rev: v0.2.0
     hooks:
     -   id: validate-changelog
--   repo: https://github.com/matthewhughes934/golines
-    rev: v0.12.0
-    hooks:
-    -   id: golines
-        exclude: testdata
 -   repo: https://gitlab.com/matthewhughes/go-pre-commit
     rev: v0.3.0
     hooks:


### PR DESCRIPTION
- Move to `golangci-lint` v2

    Drop `golines` as a separate `pre-commit` hook as it's now bundled into
    `golangci-lint`. Also drop the Go version specification there: Go 1.23
    is now the minimum version this library supports

- Run checks on two latest Go versions